### PR TITLE
Make extension compatible with Magento 2.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "TIG Magento 2 Vendiro extension",
     "require": {
         "php": "~7.1|~7.2|~7.3",
-        "magento/framework": ">=101.0.0,<=101.0.10|>=102.0.0,<=102.0.3|102.0.2-p2"
+        "magento/framework": "^101.0|^102.0"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",


### PR DESCRIPTION
The extension was not compatible with Magento 2.3.5. To solve that
the requirement for the Magento Framework has been updated to match
the version used in Magento 2.3.5.