### PR TITLE
Fix error Call to undefined method Magento\Sales\Model\Order\Shipment…

### DIFF
--- a/Plugin/Shipment/Save.php
+++ b/Plugin/Shipment/Save.php
@@ -121,7 +121,7 @@ class Save
             $tracks = $shipment->getTracks();
         }
 
-        if (!$tracks) {
+        if (!$tracks && $subject instanceof \Magento\Sales\Api\Data\ShipmentInterface) {
             $tracks = $subject->getTracks();
         }
 


### PR DESCRIPTION
Fix error Call to undefined method Magento\Sales\Model\Order\Shipment…Repository\Interceptor::getTracks()

The class `\TIG\Vendiro\Plugin\Shipment\Save` is used for two plugins:
```
<type name="Magento\Sales\Api\Data\ShipmentInterface">
    <plugin name="ShipmentCreate" type="TIG\Vendiro\Plugin\Shipment\Save" />
</type>
<type name="Magento\Sales\Api\ShipmentRepositoryInterface">
    <plugin name="ShipmentCreate" type="TIG\Vendiro\Plugin\Shipment\Save" />
</type>
```

In this class there's the method `getTracks`:

```
    public function getTracks($subject, $shipment = null)
    {
        $tracks = null;
        if ($shipment) {
            $tracks = $shipment->getTracks();
        }

        if (!$tracks) {
            $tracks = $subject->getTracks();
        }

        $tracks = $this->filterTracks($tracks);
        $tracks = array_unique($tracks, SORT_REGULAR);

        return $tracks;
    }
```

When this class is being used for `Magento\Sales\Api\ShipmentRepositoryInterface` and there's no shipment or the shipment doesn't contain any tracks the code `$subject->getTracks();` will throw the error `Call to undefined method Magento\Sales\Model\Order\Shipment…Repository\Interceptor::getTracks()`. This is because the $subject (`Magento\Sales\Api\ShipmentRepositoryInterface`) doesn't have this method.

In this PR we fix this by checking if `$subject instanceof \Magento\Sales\Api\Data\ShipmentInterface`