### PR TITLE
Fix/shipment plugin

### DIFF
--- a/Plugin/Shipment/Save.php
+++ b/Plugin/Shipment/Save.php
@@ -69,11 +69,11 @@ class Save
 
         $order = $shipment->getOrder();
 
-        if ($order->getShippingMethod() != 'tig_vendiro_shipping') {
-            return;
+        if ($order->getShippingMethod() === 'tig_vendiro_shipping') {
+            $this->saveVendiroCarrier($shipment);
         }
 
-        $this->saveVendiroCarrier($shipment);
+        return [$shipment];
     }
 
     /**
@@ -96,15 +96,15 @@ class Save
         $order = $shipment->getOrder();
         $shippingMethod = $order->getShippingMethod();
 
-        if ($shippingMethod !== 'tig_vendiro_shipping') {
-            return;
+        if ($shippingMethod === 'tig_vendiro_shipping') {
+            $tracks = $this->getTracks($subject, $shipment);
+
+            foreach ($tracks as $track) {
+                $this->saveTrack($track);
+            }
         }
 
-        $tracks = $this->getTracks($subject, $shipment);
-
-        foreach ($tracks as $track) {
-            $this->saveTrack($track);
-        }
+        return $shipment;
     }
 
     /**

--- a/Plugin/Shipment/Save.php
+++ b/Plugin/Shipment/Save.php
@@ -73,7 +73,7 @@ class Save
             $this->saveVendiroCarrier($shipment);
         }
 
-        return [$shipment];
+        return null;
     }
 
     /**


### PR DESCRIPTION
The before and after plugin have an incorrect return statement. Magento documentation states that for a before statement you need to retrun an array of the parameters of the method if one or more are changed. Or return NULL when no parameter is changed. Currently the return statement is VOID, which results in the parent method not receiving any value for the $shipment parameter.

Also the after statement is wrong. It should also return the value of the parent method.

This is a big bug resulting in errors when creating shipment for non vendiro orders.

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html