### PR TITLE
Add entity_id to filter track collection

### DIFF
--- a/Service/TrackTrace/Data.php
+++ b/Service/TrackTrace/Data.php
@@ -154,6 +154,7 @@ class Data
     {
         $trackCollection = $this->collectionFactory->create();
         $trackId = $trackQueueItem->getTrackId();
+        $trackCollection->addFieldToFilter('entity_id', $trackId);
         $track = $trackCollection->getItemById($trackId);
 
         return $track;


### PR DESCRIPTION
Creating a collection and only doing `getItemById` without any filtering will result in fetching every record from the database. For our shop we currently have 340.000 Shipment Tracks in the database. This methods returns all 340.000 records and places them all in the `_items` array of the colleciton object. That's costing a lot of time and memory. Then the method `getItemById` only returns that one record and that's being returned by the method. For 100 shipments the cron task took around 30 minutes.

We've patched this by adding a `addFieldToFilter` to the collection fetching only the record we need. Now the cron only takes 30s.