### PR TITLE
Deprecation warning fix for PHP 8.1 when discount description is null

### DIFF
--- a/Model/Totals/Creditmemo/Discount.php
+++ b/Model/Totals/Creditmemo/Discount.php
@@ -99,7 +99,7 @@ class Discount extends AbstractTotal
         $foundVendiroOrders = $this->orderRepository->getByFieldWithValue('order_id', $order->getIncrementId());
 
         //Validate if order came from Vendiro
-        if (empty($foundVendiroOrders) || strpos($order->getDiscountDescription(), "Vendiro") === false) {
+        if (empty($foundVendiroOrders) || strpos((string)$order->getDiscountDescription(), "Vendiro") === false) {
             return false;
         }
 


### PR DESCRIPTION
When using PHP8.1 a deprecation warning error popups which should get fixed in this PR